### PR TITLE
Remove duplicate actions: read permission from Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 


### PR DESCRIPTION
The actions: read permission was specified twice - once in the main permissions section and once in additional_permissions. Removed the redundant additional_permissions setting since it's already defined in the job permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)